### PR TITLE
main.go: update module to have correct github path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/soypete/Metup-Go-Graphql-Scraper
+module github.com/soypete/Meetup-Go-Graphql-Scraper
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/soypete/Metup-Go-Graphql-Scraper/auth"
-	"github.com/soypete/Metup-Go-Graphql-Scraper/meetup"
+	"github.com/soypete/Meetup-Go-Graphql-Scraper/auth"
+	"github.com/soypete/Meetup-Go-Graphql-Scraper/meetup"
 )
 
 type Config struct {


### PR DESCRIPTION
I need the github path and the module path to be in sync for `go install` to work. 